### PR TITLE
sdm845-common: Remove QTI BT soong namespaces

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,7 +1,3 @@
 soong_namespace {
-    imports: [
-        "hardware/qcom/bootctrl",
-        "vendor/qcom/opensource/commonsys/packages/apps/Bluetooth",
-        "vendor/qcom/opensource/commonsys/system/bt/conf",
-    ],
+    imports: ["hardware/qcom/bootctrl"],
 }

--- a/common.mk
+++ b/common.mk
@@ -180,9 +180,7 @@ PRODUCT_PACKAGES += \
 # Soong namespaces
 PRODUCT_SOONG_NAMESPACES += \
     $(LOCAL_PATH) \
-    device/oneplus/common \
-    vendor/qcom/opensource/commonsys/packages/apps/Bluetooth \
-    vendor/qcom/opensource/commonsys/system/bt/conf
+    device/oneplus/common
 
 # Sounds
 PRODUCT_PRODUCT_PROPERTIES += \


### PR DESCRIPTION
* TARGET_USE_QTI_BT_STACK flag will take care BT soong namespaces.
* Reference: https://github.com/Havoc-OS/android_vendor_havoc/commit/b018df8dcfc48779d49d0de9bf342f08ea9680be.

Revert "sdm845-common: Add bt_stack_qti.conf to soong namespaces"

This reverts commit 0d706c7a4529eb90062a87dffde8a33977f5a3a6.

Revert "sdm845-common: QTI BT: Import vendor/qcom/opensource/commonsys/packages/apps/Bluetooth soong namespace"

This reverts commit 2fc92505f3451c44bd289fa4a9f7038ac45420c2.

Signed-off-by: chandu078 <chandudyavanapelli03@gmail.com>